### PR TITLE
Document file format restrictions for textfile collector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ that are tied to a machine.
 To use it, set the `--collector.textfile.directory` flag on the Node exporter. The
 collector will parse all files in that directory matching the glob `*.prom`
 using the [text
-format](http://prometheus.io/docs/instrumenting/exposition_formats/).
+format](http://prometheus.io/docs/instrumenting/exposition_formats/) but without
+timestamps. Including a client-side timestamp with a metric will cause the
+whole file to be skipped.
 
 To atomically push completion time for a cron job:
 ```


### PR DESCRIPTION
Treating timestamps as errors is a breaking change if your files used to include them. There was no hint in the documentation about having to leave them out. I hope these lines can clarify this and spare others the bug hunt. ;-) Thanks @superq@gmail.com and @github@freigeist.org